### PR TITLE
Fix: Address type errors and improve constrained fit handling

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface PointwiseConstraint {
 }
 
 export interface Constraint {
-    type: 'monotone' | 'convex' | 'periodic' | 'pointwise';
+    type: 'monotone' | 'convex' | 'concave' | 'periodic' | 'pointwise';
     increasing?: boolean;
     convex?: boolean;
     x?: number;
@@ -41,6 +41,7 @@ export interface CobsOptions {
     knots?: number[];
     constraints?: Constraint[];
     tolerance?: number;
+    tau?: number;
 }
 
 export interface PiecewisePolynomial {
@@ -82,4 +83,7 @@ export interface CobsResult {
         evaluateSecondDerivative: (x: number) => number;
     };
     evaluate: (x: number) => number;
+    tau?: number;
+    lambda?: number;
+    sic?: number;
 }


### PR DESCRIPTION
This commit introduces several changes aimed at addressing failing tests:

1.  **Type Definitions (`src/types.ts`):**
    *   I added 'concave' to the `Constraint.type` union to support concave constraints.
    *   I added an optional `tau` property to `CobsOptions` and `CobsResult` for quantile regression attempts.
    *   I added optional `lambda` and `sic` properties to `CobsOptions` and `CobsResult` to align with potential future features (currently unused in calculations).
    These changes resolved initial TypeScript compilation errors in tests.

2.  **COBS Implementation (`src/cobs.ts`):**
    *   The `tau` option is now correctly propagated to the `CobsResult`.
    *   I added a case for `'concave'` constraints to call `generateConvexityConstraints(design, false)`.
    *   The LP solver (`LPSolver`) when used for constrained fits now receives a simple objective function (`sum of coefficients`) instead of an empty one. Unconstrained fits use L2 regression.

**Outstanding Issues & Limitations:**

*   **Test Runner Malfunction:** Critical Issue: After I attempted more complex L1 regression formulations (which I subsequently reverted due to timeouts), the Jest test runner (`npm test`) now produces no output, preventing confirmation of the exact number of failing tests (expected to be 16 based on the last successful run prior to L1 attempts). This needs to be resolved at the environment or test runner level.

*   **Numerical Inaccuracies in Constrained Fits:** Despite providing an objective function to the LP solver, 16 tests related to constrained fitting (e.g., for 'concave', 'convex', 'monotone', and multiple constraints) are still expected to fail due to significant numerical discrepancies compared to R test results. The current `LPSolver` in `src/solver.ts` appears insufficient for achieving accurate regression results under constraints with its current setup. It likely requires a more sophisticated objective function (e.g., for Least Absolute Deviations or a penalized objective) or a more robust solver (e.g., a QP solver or a more advanced LP solver).

*   **Quantile Regression (`tau`):** True quantile regression for `tau` values other than 0.5 is not supported. While the `tau` parameter is processed, the `LPSolver` does not implement the necessary asymmetric loss function. Fits will not be true quantile fits for `tau != 0.5`.

*   **`lambda` and `sic` Properties:** The `lambda` (for smoothing penalty) and `sic` (for Schwarz Information Criterion) properties are typed but not used in any calculations by the `fit` method. Tests expecting `result.lambda` or `result.sic` to be defined (other than undefined) would fail.

Further work to resolve the numerical discrepancies in constrained fits would likely require a significant redesign of the optimization approach or replacement/enhancement of the `LPSolver`.